### PR TITLE
Pull Request for Issue #42 (Allow Ground Base to be removed)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,63 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/Parts/concreteBase1/part.cfg
+++ b/Parts/concreteBase1/part.cfg
@@ -32,6 +32,7 @@ PART
 		volumeOverride = 100
 		stackable = true
 		allowAttachOnStatic = true
+		alwaysDetachable = true
 	}
 	MODULE
 	{

--- a/Plugins/Source/KIS.csproj
+++ b/Plugins/Source/KIS.csproj
@@ -31,12 +31,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>E:\Games\KSP\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\Steam Games\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="UnityEngine">
-      <HintPath>E:\Games\KSP\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\Steam Games\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/Source/KISAddonPickup.cs
+++ b/Plugins/Source/KISAddonPickup.cs
@@ -322,6 +322,7 @@ namespace KIS
                 if (hoverInventoryGui()) return;
                 if (draggedPart == part) return;
                 ModuleKISPickup pickupModule = GetActivePickupNearest(part);
+                ModuleKISItem partItemModule = part.GetComponent<ModuleKISItem>();
                 ModuleKISPartDrag pDrag = part.GetComponent<ModuleKISPartDrag>();
                 ModuleKISPartMount parentMount = null;
                 if (part.parent) parentMount = part.parent.GetComponent<ModuleKISPartMount>();
@@ -357,7 +358,7 @@ namespace KIS
                 }
 
                 // Check part childrens
-                if (part.children.Count > 0)
+                if (part.children.Count > 0 && (partItemModule != null && !partItemModule.alwaysDetachable))
                 {
                     CursorEnable("KIS/Textures/forbidden", "Can't grab", "(Part can't be grabbed because " + part.children.Count + " part(s) is attached to it");
                     return;

--- a/Plugins/Source/ModuleKISItem.cs
+++ b/Plugins/Source/ModuleKISItem.cs
@@ -52,6 +52,8 @@ namespace KIS
         public bool allowAttachOnStatic = false;
         [KSPField]
         public bool editorItemsCategory = true;
+        [KSPField]
+        public bool alwaysDetachable = false;
 
 
         public virtual void OnItemUse(KIS_Item item, KIS_Item.UseFrom useFrom)


### PR DESCRIPTION
I simply added a new bool to ModuleKISItem called 'alwaysDetachable' which when set to true, will allow a part to always be detached regardless of how many parts are connected to it. You will still be limited by the other checks such as needed a tool/needing enough kerbals if the part is heavy.

I added the variable into the concreteBase item's .cfg to allow it to make use of this field. Also, the Ground Pylon in KAS could make good use of this.
