### PR TITLE
Merill more api

### DIFF
--- a/Plugins/Source/IAttachTool.cs
+++ b/Plugins/Source/IAttachTool.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections;
+using System.Text;
+using UnityEngine;
+
+namespace KIS
+{
+
+    public interface IAttachTool
+    {
+
+        //
+        // Summary:
+        //     Called when a part is Detach (from an other part).
+        //     srcPart it's the part being dropped (it's attach to its parent)
+        //     errorMsg is the string array needed when it's not possible to detach
+        //      (first is the texture, then some messages)
+        // default : check maxmass
+        bool OnCheckDetach(Part partToDetach, ref String[] errorMsg);
+
+        //
+        // Summary:
+        //     Called when a part is dropped.
+        //     srcPart it's the part being dropped
+        //     previousParent is the previous parent part of srcPart
+        void OnAttachToolUsed(Part srcPart, Part previousParent, KISAttachType moveType, KISAddonPointer.PointerTarget pointerTarget);
+
+        //
+        // Summary:
+        //     Called when a part need to known if it can be surface-attach with this tool
+        //     srcPart it's the part we want to attach
+        //     tgtPart is where we want to attach srcPart
+        //     toolInvalidMsg is the message used when this method return false.
+        //     surfaceMountPosition is the surface mount position on tgtPart (in scene origin)
+        bool OnCheckAttach(Part srcPart, Part tgtPart, ref string toolInvalidMsg, Vector3 surfaceMountPosition);
+
+        //
+        // Summary:
+        //     Called when a part need to known if it can be attachon a node with this tool
+        //     srcPart it's the part we want to attach
+        //     tgtPart is where we want to attach srcPart
+        //     toolInvalidMsg is the message used when this method return false.
+        //     surfaceMountPosition is the surface mount position on tgtPart (in scene origin)
+        bool OnCheckAttach(Part srcPart, Part tgtPart, ref string toolInvalidMsg, AttachNode tgtNode);
+    }
+    
+    public enum KISAttachType { DETACH, ATTACH, DETACH_AND_ATTACH }
+
+}

--- a/Plugins/Source/KIS.csproj
+++ b/Plugins/Source/KIS.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DependancyChecker.cs" />
+    <Compile Include="KISIAttachTool.cs" />
     <Compile Include="ModuleKISItemEvaPropellant.cs" />
     <Compile Include="KIS_IconViewer.cs" />
     <Compile Include="ModuleKISItemBook.cs" />

--- a/Plugins/Source/KISAddonConfig.cs
+++ b/Plugins/Source/KISAddonConfig.cs
@@ -76,7 +76,6 @@ namespace KIS
                 if (nodeEvaPickup.HasValue("maxDistance")) evaPickup.maxDistance = float.Parse(nodeEvaPickup.GetValue("maxDistance"));
                 if (nodeEvaPickup.HasValue("maxMass")) evaPickup.maxMass = float.Parse(nodeEvaPickup.GetValue("maxMass"));
                 if (nodeEvaPickup.HasValue("dropSndPath")) evaPickup.dropSndPath = nodeEvaPickup.GetValue("dropSndPath");
-                if (nodeEvaPickup.HasValue("attachSndPath")) evaPickup.attachSndPath = nodeEvaPickup.GetValue("attachSndPath");
                 if (nodeEvaPickup.HasValue("draggedIconResolution")) KISAddonPickup.draggedIconResolution = int.Parse(nodeEvaPickup.GetValue("draggedIconResolution"));
                 KIS_Shared.DebugLog("Eva pickup module loaded successfully");
             }
@@ -108,7 +107,6 @@ namespace KIS
                 if (nodeEvaPickup.HasValue("maxDistance")) evaFemalePickup.maxDistance = float.Parse(nodeEvaPickup.GetValue("maxDistance"));
                 if (nodeEvaPickup.HasValue("maxMass")) evaFemalePickup.maxMass = float.Parse(nodeEvaPickup.GetValue("maxMass"));
                 if (nodeEvaPickup.HasValue("dropSndPath")) evaFemalePickup.dropSndPath = nodeEvaPickup.GetValue("dropSndPath");
-                if (nodeEvaPickup.HasValue("attachSndPath")) evaFemalePickup.attachSndPath = nodeEvaPickup.GetValue("attachSndPath");
                 if (nodeEvaPickup.HasValue("draggedIconResolution")) KISAddonPickup.draggedIconResolution = int.Parse(nodeEvaPickup.GetValue("draggedIconResolution"));
                 KIS_Shared.DebugLog("Eva pickup module loaded successfully");
             }

--- a/Plugins/Source/KISAddonPickup.cs
+++ b/Plugins/Source/KISAddonPickup.cs
@@ -43,7 +43,7 @@ namespace KIS
         public Part hoveredPart = null;
         public bool grabActive = false;
         private bool grabOk = false;
-        private IAttachTool detachTool;
+        private KISIAttachTool detachTool;
         private bool jetpackLock = false;
 
         public enum PointerMode { Drop, Attach }
@@ -397,7 +397,7 @@ namespace KIS
                     {
                         //check if tool can detach
                         string[] errorMsg = null;
-                        IAttachTool checkDetachTool = KIS_Shared.CheckAttachTool(x => x.OnCheckDetach(part, ref errorMsg));
+                        KISIAttachTool checkDetachTool = KIS_Shared.CheckAttachTool(x => x.OnCheckDetach(part, ref errorMsg));
                         if (checkDetachTool == null)
                         {
                             if (errorMsg == null)
@@ -661,7 +661,7 @@ namespace KIS
             }
         }
 
-        private void OnPointerAction(KISAddonPointer.PointerTarget pointerTarget, Vector3 pos, Quaternion rot, Part tgtPart, IAttachTool attachTool, string srcAttachNodeID = null, AttachNode tgtAttachNode = null)
+        private void OnPointerAction(KISAddonPointer.PointerTarget pointerTarget, Vector3 pos, Quaternion rot, Part tgtPart, KISIAttachTool attachTool, string srcAttachNodeID = null, AttachNode tgtAttachNode = null)
         {
             if (pointerTarget == KISAddonPointer.PointerTarget.PartMount)
             {

--- a/Plugins/Source/KISAddonPointer.cs
+++ b/Plugins/Source/KISAddonPointer.cs
@@ -73,7 +73,7 @@ namespace KIS
         public static PointerTarget pointerTarget = PointerTarget.Nothing;
         public enum PointerTarget { Nothing, Static, StaticRb, Part, PartNode, PartMount, KerbalEva }
         private static OnPointerClick SendPointerClick;
-        public delegate void OnPointerClick(PointerTarget pTarget, Vector3 pos, Quaternion rot, Part pointerPart, ModuleKISItemAttachTool attachTool, string SrcAttachNodeID = null, AttachNode tgtAttachNode = null);
+        public delegate void OnPointerClick(PointerTarget pTarget, Vector3 pos, Quaternion rot, Part pointerPart, IAttachTool attachTool, string SrcAttachNodeID = null, AttachNode tgtAttachNode = null);
 
         public enum PointerState { OnMouseEnterPart, OnMouseExitPart, OnMouseEnterNode, OnMouseExitNode, OnChangeAttachNode }
         private static OnPointerState SendPointerState;
@@ -527,7 +527,7 @@ namespace KIS
             bool itselfIsInvalid = false;
             bool toolIsInvalid = false;
             string toolInvalidMsg = "";
-			ModuleKISItemAttachTool attachTool = null;
+			IAttachTool attachTool = null;
             switch (pointerTarget)
             {
                 case PointerTarget.Static:

--- a/Plugins/Source/KISAddonPointer.cs
+++ b/Plugins/Source/KISAddonPointer.cs
@@ -73,7 +73,7 @@ namespace KIS
         public static PointerTarget pointerTarget = PointerTarget.Nothing;
         public enum PointerTarget { Nothing, Static, StaticRb, Part, PartNode, PartMount, KerbalEva }
         private static OnPointerClick SendPointerClick;
-        public delegate void OnPointerClick(PointerTarget pTarget, Vector3 pos, Quaternion rot, Part pointerPart, string SrcAttachNodeID = null, AttachNode tgtAttachNode = null);
+        public delegate void OnPointerClick(PointerTarget pTarget, Vector3 pos, Quaternion rot, Part pointerPart, ModuleKISItemAttachTool attachTool, string SrcAttachNodeID = null, AttachNode tgtAttachNode = null);
 
         public enum PointerState { OnMouseEnterPart, OnMouseExitPart, OnMouseEnterNode, OnMouseExitNode, OnChangeAttachNode }
         private static OnPointerState SendPointerState;
@@ -525,6 +525,9 @@ namespace KIS
             bool cannotSurfaceAttach = false;
             bool invalidCurrentNode = false;
             bool itselfIsInvalid = false;
+            bool toolIsInvalid = false;
+            string toolInvalidMsg = "";
+			ModuleKISItemAttachTool attachTool = null;
             switch (pointerTarget)
             {
                 case PointerTarget.Static:
@@ -548,24 +551,31 @@ namespace KIS
                         }
                         else
                         {
-                            if (useAttachRules)
+                            //check if the tool is ok to do the job
+							attachTool = KIS_Shared.CheckAttachTool(x => x.OnCheckAttach(partToAttach, hoveredPart,
+                                    ref toolInvalidMsg, pointer.transform.position));
+							toolIsInvalid = attachTool == null;
+                            if (!toolIsInvalid)
                             {
-                                if (hoveredPart.attachRules.allowSrfAttach)
+                                if (useAttachRules)
                                 {
-                                    if (GetCurrentAttachNode().nodeType == AttachNode.NodeType.Surface)
+                                    if (hoveredPart.attachRules.allowSrfAttach)
                                     {
-                                        color = Color.green;
+                                        if (GetCurrentAttachNode().nodeType == AttachNode.NodeType.Surface)
+                                        {
+                                            color = Color.green;
+                                        }
+                                        else
+                                        {
+                                            invalidCurrentNode = true;
+                                        }
                                     }
-                                    else
-                                    {
-                                        invalidCurrentNode = true;
-                                    }
+                                    else cannotSurfaceAttach = true;
                                 }
-                                else cannotSurfaceAttach = true;
-                            }
-                            else
-                            {
-                                color = Color.green;
+                                else
+                                {
+                                    color = Color.green;
+                                }
                             }
                         }
                     }
@@ -589,7 +599,15 @@ namespace KIS
                     }
                     break;
                 case PointerTarget.PartNode:
-                    if (allowStack) color = XKCDColors.SeaGreen;
+                    if (allowStack)
+                    {
+						attachTool = KIS_Shared.CheckAttachTool(x => x.OnCheckAttach(partToAttach, hoveredPart,
+                                ref toolInvalidMsg, hoveredNode));
+						toolIsInvalid = attachTool == null;
+                        if (!toolIsInvalid)
+                            color = XKCDColors.SeaGreen;
+
+                    }
                     else invalidTarget = true;
                     break;
                 default:
@@ -606,6 +624,12 @@ namespace KIS
             //On click
             if (Input.GetKeyDown(KeyCode.Mouse0))
             {
+                if (toolIsInvalid)
+                {
+                    ScreenMessages.PostScreenMessage(toolInvalidMsg);
+                    audioBipWrong.Play();
+                    return;
+                }
                 if (invalidTarget)
                 {
                     ScreenMessages.PostScreenMessage("Target object is not allowed !");
@@ -650,7 +674,7 @@ namespace KIS
                 }
                 else
                 {
-                    SendPointerClick(pointerTarget, pointer.transform.position, pointer.transform.rotation, hoveredPart, GetCurrentAttachNode().id, hoveredNode);
+					SendPointerClick(pointerTarget, pointer.transform.position, pointer.transform.rotation, hoveredPart, attachTool, GetCurrentAttachNode().id, hoveredNode);
                 }
             }
         }

--- a/Plugins/Source/KISAddonPointer.cs
+++ b/Plugins/Source/KISAddonPointer.cs
@@ -73,7 +73,7 @@ namespace KIS
         public static PointerTarget pointerTarget = PointerTarget.Nothing;
         public enum PointerTarget { Nothing, Static, StaticRb, Part, PartNode, PartMount, KerbalEva }
         private static OnPointerClick SendPointerClick;
-        public delegate void OnPointerClick(PointerTarget pTarget, Vector3 pos, Quaternion rot, Part pointerPart, IAttachTool attachTool, string SrcAttachNodeID = null, AttachNode tgtAttachNode = null);
+        public delegate void OnPointerClick(PointerTarget pTarget, Vector3 pos, Quaternion rot, Part pointerPart, KISIAttachTool attachTool, string SrcAttachNodeID = null, AttachNode tgtAttachNode = null);
 
         public enum PointerState { OnMouseEnterPart, OnMouseExitPart, OnMouseEnterNode, OnMouseExitNode, OnChangeAttachNode }
         private static OnPointerState SendPointerState;
@@ -527,7 +527,7 @@ namespace KIS
             bool itselfIsInvalid = false;
             bool toolIsInvalid = false;
             string toolInvalidMsg = "";
-			IAttachTool attachTool = null;
+			KISIAttachTool attachTool = null;
             switch (pointerTarget)
             {
                 case PointerTarget.Static:

--- a/Plugins/Source/KISIAttachTool.cs
+++ b/Plugins/Source/KISIAttachTool.cs
@@ -7,7 +7,12 @@ using UnityEngine;
 
 namespace KIS
 {
-
+    //
+    // Summary:
+    //          Interface for item who can attach and detach parts from other parts.
+    //          /!\ At this time, you MUST set item.inventory.part.GetComponent<ModuleKISPickup>().canDetach = true; 
+    //              in onEquip to make it work (and to false value in onUnequip)
+    //          Your item MUST be in the right hand, to make it work & be compliant with the doc
     public interface KISIAttachTool
     {
 

--- a/Plugins/Source/KISIAttachTool.cs
+++ b/Plugins/Source/KISIAttachTool.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace KIS
 {
 
-    public interface IAttachTool
+    public interface KISIAttachTool
     {
 
         //

--- a/Plugins/Source/KISIAttachTool.cs
+++ b/Plugins/Source/KISIAttachTool.cs
@@ -43,7 +43,7 @@ namespace KIS
 
         //
         // Summary:
-        //     Called when a part need to known if it can be attachon a node with this tool
+        //     Called when a part need to known if it can be attach on a node with this tool
         //     srcPart it's the part we want to attach
         //     tgtPart is where we want to attach srcPart
         //     toolInvalidMsg is the message used when this method return false.

--- a/Plugins/Source/KIS_Shared.cs
+++ b/Plugins/Source/KIS_Shared.cs
@@ -595,5 +595,37 @@ namespace KIS
             return btnPress;
         }
 
+		//public static bool CheckAttachTool(Func<ModuleKISItemAttachTool, bool> toExecute)
+		//{
+		//	List<ModuleKISInventory> inventories = FlightGlobals.ActiveVessel.FindPartModulesImplementing<ModuleKISInventory>();
+		//	bool checkOk = false;
+		//	foreach (ModuleKISInventory inventory in inventories)
+		//	{
+		//		KIS_Item item = inventory.GetEquipedItem("rightHand");
+		//		if (item != null && item.prefabModule != null && item.prefabModule is ModuleKISItemAttachTool)
+		//		{
+		//			checkOk = toExecute(item.prefabModule as ModuleKISItemAttachTool);
+		//			if (checkOk) return true;
+		//		}
+		//	}
+		//	return false;
+		//}
+
+		public static ModuleKISItemAttachTool CheckAttachTool(Func<ModuleKISItemAttachTool, bool> toExecute)
+		{
+			List<ModuleKISInventory> inventories = FlightGlobals.ActiveVessel.FindPartModulesImplementing<ModuleKISInventory>();
+			bool checkOk = false;
+			foreach (ModuleKISInventory inventory in inventories)
+			{
+				KIS_Item item = inventory.GetEquipedItem("rightHand");
+				if (item != null && item.prefabModule != null && item.prefabModule is ModuleKISItemAttachTool)
+				{
+					checkOk = toExecute(item.prefabModule as ModuleKISItemAttachTool);
+					if (checkOk) return item.prefabModule as ModuleKISItemAttachTool;
+				}
+			}
+			return null;
+		}
+
     }
 }

--- a/Plugins/Source/KIS_Shared.cs
+++ b/Plugins/Source/KIS_Shared.cs
@@ -595,22 +595,6 @@ namespace KIS
             return btnPress;
         }
 
-		//public static bool CheckAttachTool(Func<ModuleKISItemAttachTool, bool> toExecute)
-		//{
-		//	List<ModuleKISInventory> inventories = FlightGlobals.ActiveVessel.FindPartModulesImplementing<ModuleKISInventory>();
-		//	bool checkOk = false;
-		//	foreach (ModuleKISInventory inventory in inventories)
-		//	{
-		//		KIS_Item item = inventory.GetEquipedItem("rightHand");
-		//		if (item != null && item.prefabModule != null && item.prefabModule is ModuleKISItemAttachTool)
-		//		{
-		//			checkOk = toExecute(item.prefabModule as ModuleKISItemAttachTool);
-		//			if (checkOk) return true;
-		//		}
-		//	}
-		//	return false;
-		//}
-
 		public static ModuleKISItemAttachTool CheckAttachTool(Func<ModuleKISItemAttachTool, bool> toExecute)
 		{
 			List<ModuleKISInventory> inventories = FlightGlobals.ActiveVessel.FindPartModulesImplementing<ModuleKISInventory>();

--- a/Plugins/Source/ModuleKISItemAttachTool.cs
+++ b/Plugins/Source/ModuleKISItemAttachTool.cs
@@ -93,7 +93,7 @@ namespace KIS
         public virtual bool OnCheckDetach(Part partToDetach, ref String[] errorMsg)
         {
             if (partToDetach == null) return true;
-            float pMass = (part.mass + part.GetResourceMass());
+            float pMass = (partToDetach.mass + partToDetach.GetResourceMass());
             if (pMass > attachMaxMass)
             {
                 errorMsg = new string[]{
@@ -136,7 +136,7 @@ namespace KIS
         // Check if the max mass is ok (but this is already done in OnItemUse)
         protected virtual bool OnCheckAttach(Part srcPart, Part tgtPart, ref string toolInvalidMsg)
         {
-            float pMass = (srcPart.mass + part.GetResourceMass());
+            float pMass = (srcPart.mass + srcPart.GetResourceMass());
             if (pMass > attachMaxMass)
             {
                 toolInvalidMsg = "Too heavy, (Use a better tool for this [" + pMass + " > " + attachMaxMass + ")";

--- a/Plugins/Source/ModuleKISItemAttachTool.cs
+++ b/Plugins/Source/ModuleKISItemAttachTool.cs
@@ -80,12 +80,6 @@ namespace KIS
             if (pickupModule)
             {
                 pickupModule.canDetach = true;
-                orgAttachMaxMass = pickupModule.detachMaxMass;
-                pickupModule.detachMaxMass = attachMaxMass;
-                orgAttachSndPath = pickupModule.attachSndPath;
-                pickupModule.attachSndPath = attachSndPath;
-                orgDetachSndPath = pickupModule.detachSndPath;
-                pickupModule.detachSndPath = detachSndPath;
             }
         }
 
@@ -95,9 +89,6 @@ namespace KIS
             if (pickupModule)
             {
                 pickupModule.canDetach = false;
-                pickupModule.detachMaxMass = orgAttachMaxMass;
-                pickupModule.attachSndPath = orgAttachSndPath;
-                pickupModule.detachSndPath = orgDetachSndPath;
             }
         }
 
@@ -124,22 +115,6 @@ namespace KIS
             return true;
         }
 
-
-        //private static float GetAllPickupMaxMassInRange(Part p)
-        //{
-        //	float maxMass = 0;
-        //	ModuleKISPickup[] allPickupModules = FindObjectsOfType(typeof(ModuleKISPickup)) as ModuleKISPickup[];
-        //	foreach (ModuleKISPickup pickupModule in allPickupModules)
-        //	{
-        //		float partDist = Vector3.Distance(pickupModule.part.transform.position, p.transform.position);
-        //		if (partDist <= pickupModule.maxDistance)
-        //		{
-        //			maxMass += pickupModule.maxMass;
-        //		}
-        //	}
-        //	return maxMass;
-        //}
-
         //
         // Summary:
         //     Called when a part is dropped.
@@ -147,14 +122,18 @@ namespace KIS
         //     tgtPart is a part src part will be going into
         public virtual void OnItemMove(Part srcPart, Part tgtPart, KISMoveType moveType, KISAddonPointer.PointerTarget pointerTarget)
         {
-            if (moveType == (KISMoveType.ATTACH_MOVE | KISMoveType.ATTACH_NEW) && srcPart)
+            Debug.Log("OnItemMove: "+(srcPart == null ? "null" : srcPart.name) + ", " + (tgtPart == null ? "null" : tgtPart.name)
+                + "; " + moveType + " - " + pointerTarget);
+            if ( (moveType == KISMoveType.ATTACH_MOVE || moveType == KISMoveType.ATTACH_NEW) && srcPart)
             {
+                Debug.Log("Play attach: " + attachSndPath);
                 AudioSource.PlayClipAtPoint(GameDatabase.Instance.GetAudioClip(attachSndPath), srcPart.transform.position);
             }
-            else
+            else if (moveType == KISMoveType.DROP_MOVE)
             {
                 if (tgtPart != null)
                 {
+                    Debug.Log("Play Detach " + detachSndPath);
                     AudioSource.PlayClipAtPoint(GameDatabase.Instance.GetAudioClip(detachSndPath), srcPart.transform.position);
                 }
             }

--- a/Plugins/Source/ModuleKISItemAttachTool.cs
+++ b/Plugins/Source/ModuleKISItemAttachTool.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace KIS
 {
 
-    public class ModuleKISItemAttachTool : ModuleKISItem, IAttachTool
+    public class ModuleKISItemAttachTool : ModuleKISItem, KISIAttachTool
     {
         [KSPField]
         public float attachMaxMass = 0.5f;
@@ -89,13 +89,7 @@ namespace KIS
             }
         }
 
-        //
-        // Summary:
-        //     Called when a part is Detach (from an other part).
-        //     srcPart it's the part being dropped (it's attach to its parent)
-        //     errorMsg is the string array needed when it's not possible to detach
-        //      (first is the texture, then some messages)
-        // default : check maxmass
+        // Check if the max mass is ok
         public virtual bool OnCheckDetach(Part partToDetach, ref String[] errorMsg)
         {
             if (partToDetach == null) return true;
@@ -112,12 +106,8 @@ namespace KIS
             return true;
         }
 
-        //
-        // Summary:
-        //     Called when a part is dropped.
-        //     srcPart it's the part being dropped
-        //     tgtPart is a part src part will be going into
-        public virtual void OnAttachToolUsed(Part srcPart, Part tgtPart, KISAttachType moveType, KISAddonPointer.PointerTarget pointerTarget)
+        // Play sound on attach & detach
+        public virtual void OnAttachToolUsed(Part srcPart, Part oldParent, KISAttachType moveType, KISAddonPointer.PointerTarget pointerTarget)
         {
             if ( (moveType == KISAttachType.DETACH_AND_ATTACH || moveType == KISAttachType.ATTACH) && srcPart)
             {
@@ -131,33 +121,22 @@ namespace KIS
             }
         }
 
-        //
-        // Summary:
-        //     Called when a part need to known if it can be surface-attach with this tool
-        //     srcPart it's the part we want to attach
-        //     tgtPart is where we want to attach srcPart
-        //     toolInvalidMsg is the message used when this method return false.
-        //     surfaceMountPosition is the surface mount position on tgtPart (in scene origin)
+        // redirect to protected bool OnCheckAttach(Part srcPart, Part tgtPart, ref string toolInvalidMsg)
         public virtual bool OnCheckAttach(Part srcPart, Part tgtPart, ref string toolInvalidMsg, Vector3 surfaceMountPosition)
         {
             return this.OnCheckAttach(srcPart, tgtPart, ref toolInvalidMsg);
         }
 
-        //
-        // Summary:
-        //     Called when a part need to known if it can be attachon a node with this tool
-        //     srcPart it's the part we want to attach
-        //     tgtPart is where we want to attach srcPart
-        //     toolInvalidMsg is the message used when this method return false.
-        //     surfaceMountPosition is the surface mount position on tgtPart (in scene origin)
+        // redirect to protected bool OnCheckAttach(Part srcPart, Part tgtPart, ref string toolInvalidMsg)
         public virtual bool OnCheckAttach(Part srcPart, Part tgtPart, ref string toolInvalidMsg, AttachNode tgtNode)
         {
             return this.OnCheckAttach(srcPart, tgtPart, ref toolInvalidMsg);
         }
 
+        // Check if the max mass is ok (but this is already done in OnItemUse)
         protected virtual bool OnCheckAttach(Part srcPart, Part tgtPart, ref string toolInvalidMsg)
         {
-            float pMass = (part.mass + part.GetResourceMass());
+            float pMass = (srcPart.mass + part.GetResourceMass());
             if (pMass > attachMaxMass)
             {
                 toolInvalidMsg = "Too heavy, (Use a better tool for this [" + pMass + " > " + attachMaxMass + ")";

--- a/Plugins/Source/ModuleKISItemAttachTool.cs
+++ b/Plugins/Source/ModuleKISItemAttachTool.cs
@@ -111,12 +111,10 @@ namespace KIS
         {
             if ( (moveType == KISAttachType.DETACH_AND_ATTACH || moveType == KISAttachType.ATTACH) && srcPart)
             {
-                Debug.Log("Play attach: " + attachSndPath);
                 AudioSource.PlayClipAtPoint(GameDatabase.Instance.GetAudioClip(attachSndPath), srcPart.transform.position);
             }
             else if (moveType == KISAttachType.DETACH && srcPart)
             {
-                Debug.Log("Play Detach " + detachSndPath);
                 AudioSource.PlayClipAtPoint(GameDatabase.Instance.GetAudioClip(detachSndPath), srcPart.transform.position);
             }
         }
@@ -136,13 +134,12 @@ namespace KIS
         // Check if the max mass is ok (but this is already done in OnItemUse)
         protected virtual bool OnCheckAttach(Part srcPart, Part tgtPart, ref string toolInvalidMsg)
         {
-            float pMass = (srcPart.mass + srcPart.GetResourceMass());
-            if (pMass > attachMaxMass)
-            {
-                toolInvalidMsg = "Too heavy, (Use a better tool for this [" + pMass + " > " + attachMaxMass + ")";
-
-                return false;
-            }
+            //float pMass = (srcPart.mass + srcPart.GetResourceMass());
+            //if (pMass > attachMaxMass)
+            //{
+            //    toolInvalidMsg = "Too heavy, (Use a better tool for this [" + pMass + " > " + attachMaxMass + ")";
+            //    return false;
+            //}
             return true;
         }
     }

--- a/Plugins/Source/ModuleKISItemAttachTool.cs
+++ b/Plugins/Source/ModuleKISItemAttachTool.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace KIS
 {
 
-    public class ModuleKISItemAttachTool : ModuleKISItem
+    public class ModuleKISItemAttachTool : ModuleKISItem, IAttachTool
     {
         [KSPField]
         public float attachMaxMass = 0.5f;
@@ -20,9 +20,6 @@ namespace KIS
         public string detachSndPath = "KIS/Sounds/detach";
         [KSPField]
         public string changeModeSndPath = "KIS/Sounds/click";
-
-        private string orgAttachSndPath, orgDetachSndPath;
-        private float orgAttachMaxMass;
 
         public override string GetInfo()
         {
@@ -120,22 +117,17 @@ namespace KIS
         //     Called when a part is dropped.
         //     srcPart it's the part being dropped
         //     tgtPart is a part src part will be going into
-        public virtual void OnItemMove(Part srcPart, Part tgtPart, KISMoveType moveType, KISAddonPointer.PointerTarget pointerTarget)
+        public virtual void OnAttachToolUsed(Part srcPart, Part tgtPart, KISAttachType moveType, KISAddonPointer.PointerTarget pointerTarget)
         {
-            Debug.Log("OnItemMove: "+(srcPart == null ? "null" : srcPart.name) + ", " + (tgtPart == null ? "null" : tgtPart.name)
-                + "; " + moveType + " - " + pointerTarget);
-            if ( (moveType == KISMoveType.ATTACH_MOVE || moveType == KISMoveType.ATTACH_NEW) && srcPart)
+            if ( (moveType == KISAttachType.DETACH_AND_ATTACH || moveType == KISAttachType.ATTACH) && srcPart)
             {
                 Debug.Log("Play attach: " + attachSndPath);
                 AudioSource.PlayClipAtPoint(GameDatabase.Instance.GetAudioClip(attachSndPath), srcPart.transform.position);
             }
-            else if (moveType == KISMoveType.DROP_MOVE)
+            else if (moveType == KISAttachType.DETACH && srcPart)
             {
-                if (tgtPart != null)
-                {
-                    Debug.Log("Play Detach " + detachSndPath);
-                    AudioSource.PlayClipAtPoint(GameDatabase.Instance.GetAudioClip(detachSndPath), srcPart.transform.position);
-                }
+                Debug.Log("Play Detach " + detachSndPath);
+                AudioSource.PlayClipAtPoint(GameDatabase.Instance.GetAudioClip(detachSndPath), srcPart.transform.position);
             }
         }
 
@@ -175,8 +167,5 @@ namespace KIS
             return true;
         }
     }
-
-    // TODO: RETURN_INVENTORY option with the associated hook
-    public enum KISMoveType { DROP_NEW, DROP_MOVE, ATTACH_NEW, ATTACH_MOVE }
 
 }

--- a/Plugins/Source/ModuleKISPickup.cs
+++ b/Plugins/Source/ModuleKISPickup.cs
@@ -10,19 +10,19 @@ namespace KIS
 
     public class ModuleKISPickup : PartModule
     {
-        [KSPField]
+        [KSPField] //with this commit, it's a shortcut to part.hasModule<ModuleKISItemAttachTool>()
         public bool canDetach = false;
-        [KSPField]
+        [KSPField] //with this commit, it sould be deleted (as the compute is done in the ModuleAttachTool)
         public float detachMaxMass = Mathf.Infinity;
         [KSPField]
         public float maxDistance = 2;
         [KSPField]
         public float maxMass = 1;
-        [KSPField]
+        [KSPField] //should be in ModuleKISItemAttachTool.onMove(Drop_xx)
         public string dropSndPath = "KIS/Sounds/drop";
-        [KSPField]
+        [KSPField] //should be in ModuleKISItemAttachTool.onMove(attach_new)
         public string attachSndPath = "KIS/Sounds/attach";
-        [KSPField]
+        [KSPField] //should be in ModuleKISItemAttachTool.onMove(xx_move)
         public string detachSndPath = "KIS/Sounds/detach";
         public FXGroup sndFx;
     }

--- a/Plugins/Source/ModuleKISPickup.cs
+++ b/Plugins/Source/ModuleKISPickup.cs
@@ -10,7 +10,7 @@ namespace KIS
 
     public class ModuleKISPickup : PartModule
     {
-        [KSPField] //it's a shortcut to 'part.hasModule<ModuleKISItemAttachTool>()'
+        [KSPField] //it's ~ a shortcut to 'rightHandEquipedItem'.Modules.Contains("KISIAttachTool")
         public bool canDetach = false;
         [KSPField]
         public float maxDistance = 2;

--- a/Plugins/Source/ModuleKISPickup.cs
+++ b/Plugins/Source/ModuleKISPickup.cs
@@ -10,20 +10,14 @@ namespace KIS
 
     public class ModuleKISPickup : PartModule
     {
-        [KSPField] //with this commit, it's a shortcut to part.hasModule<ModuleKISItemAttachTool>()
+        [KSPField] //it's a shortcut to 'part.hasModule<ModuleKISItemAttachTool>()'
         public bool canDetach = false;
-        [KSPField] //with this commit, it sould be deleted (as the compute is done in the ModuleAttachTool)
-        public float detachMaxMass = Mathf.Infinity;
         [KSPField]
         public float maxDistance = 2;
         [KSPField]
         public float maxMass = 1;
-        [KSPField] //should be in ModuleKISItemAttachTool.onMove(Drop_xx)
+        [KSPField]
         public string dropSndPath = "KIS/Sounds/drop";
-        [KSPField] //should be in ModuleKISItemAttachTool.onMove(attach_new)
-        public string attachSndPath = "KIS/Sounds/attach";
-        [KSPField] //should be in ModuleKISItemAttachTool.onMove(xx_move)
-        public string detachSndPath = "KIS/Sounds/detach";
         public FXGroup sndFx;
     }
 


### PR DESCRIPTION
Hello  
I submit a pull request to extend the public api of your marvellous mod.
It move all attach/detach logic from various class, including the grabbing module (ModuleKISPickup) to the attach module (ModuleKISAttachTool)  
In this pull request, I moved the max mass check and the attach/detach sound.
Now the grabbing code module & the attach/detach module are clearly separated.

With this change, other mods/ plugin mod can:  
- restrict the use of attach tools (ex: can't attach engines)  
- change behaviour of attach tools (ex: consume a resource when attach/detach)  
- add specials attach tools (ex: can attach parts but without electric charge inside)  
  For example, my plugin create a screw/weld distinction.  
  https://github.com/supermerill/KIS_Welder/releases/tag/0.1  

how?
4 hooks:
- OnCheckDetach : called to check if a part can be detach (push the button)
- OnCheckAttach(surface) : called to check if a part can be attach (hover)
- OnCheckAttach(node) : called to check if a part can be attach (hover)
- OnAttachToolUsed : called after a attach/detach event

note : I let the 'canDetach' field in the ModuleKISPickup, but i think it should be erased and replace by a contains(KISIAttachTool), but i didn't really know the implication for the others mod that depends on KIS. So I let you decide if it can be also scrapped.

ps: sorry for my bad english skills.
