### PR TITLE
Command seat icon fix plus

### DIFF
--- a/Plugins/Source/KIS_IconViewer.cs
+++ b/Plugins/Source/KIS_IconViewer.cs
@@ -53,17 +53,14 @@ namespace KIS
                 iconPrefab = UnityEngine.Object.Instantiate((UnityEngine.Object)p.partInfo.iconPrefab) as GameObject;
                 
                 // Command Seat Icon Fix (Temporary workaround until squad fix the broken shader)
-                if (p.partInfo.name == "seatExternalCmd")
+                Shader fixShader = Shader.Find("KSP/Alpha/Cutoff Bumped");
+                foreach (Renderer r in iconPrefab.GetComponentsInChildren<Renderer>(true))
                 {
-                    Shader fixShader = Shader.Find("KSP/Alpha/Cutoff Bumped");
-                    foreach (Renderer r in iconPrefab.GetComponentsInChildren<Renderer>(true))
+                    foreach (Material m in r.materials)
                     {
-                        foreach (Material m in r.materials)
+                        if (m.shader.name == "KSP/Alpha/Cutoff")
                         {
-                            if (m.shader.name == "KSP/Alpha/Cutoff")
-                            {
-                                m.shader = fixShader;
-                            }
+                            m.shader = fixShader;
                         }
                     }
                 }


### PR DESCRIPTION
I changed the logic a bit: now it fixes KIS icons for all parts.
P.S. Git diff is a bit odd. Here is what I changed:

```
- if (p.partInfo.name == "seatExternalCmd")
- {
      Shader fixShader = Shader.Find("KSP/Alpha/Cutoff Bumped");
      foreach (Renderer r in iconPrefab.GetComponentsInChildren<Renderer>(true))
      {
          foreach (Material m in r.materials)
          {
              if (m.shader.name == "KSP/Alpha/Cutoff")
              {
                  m.shader = fixShader;
              }
          }
      }
- }
```
