### PR TITLE
Add bottom attachment node to container mount

### DIFF
--- a/Parts/containerMount1/containerMount1.cfg
+++ b/Parts/containerMount1/containerMount1.cfg
@@ -6,6 +6,7 @@ PART
 	mesh = model.mu
 	scale = 1
 	node_stack_top = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_bottom = 0.0, -0.041799, 0.0, 0.0, -1.0, 0.0, 0
 	node_attach = 0.0, -0.041799, 0.0, 0.0, -1.0, 0.0, 0
 	TechRequired = generalConstruction
 	entryCost = 3200


### PR DESCRIPTION
This adds a small attachment node to the bottom of the container mount, to allow for precise positioning when attaching it in the field.  In particular, it fits nicely on top of the small structural panel, on the side of the MKS MultiTruss or MiniTruss, and on the bed of the USI Akita rover — all of which have attachment nodes.

(Of course, the container can already be attached directly to those nodes, but that requires an engineer with a screwdriver.  This change effectively allows an engineer to make any attachment node accessible to non-engineers for container placement.)