### PR TITLE
Disallow ILC-18k on container mount

### DIFF
--- a/Parts/containerMount1/containerMount1.cfg
+++ b/Parts/containerMount1/containerMount1.cfg
@@ -35,7 +35,6 @@ PART
 		{
 			attachNode = top
 			allowedPartName= KIS_Container1
-			allowedPartName= KIS_Container2
 		}
 	}
 }


### PR DESCRIPTION
The container mount allowed both the small SC-62 surface-attachable container and the big 2.5m ILC-18k inline container, though not the smaller 2.5m ISC-6k.  It doesn't make much sense to put an ILC-18k on the container mount, so I'm guessing that was a bug.