### PR TITLE
Add quadrant attachment nodes to stock 2x2 panel

### DIFF
--- a/Patches/MM-StockParts.cfg
+++ b/Patches/MM-StockParts.cfg
@@ -17,3 +17,17 @@
 		editorItemsCategory = false
 	}
 }
+
+// Add an attachment node in the center of each quadrant of the stock 2x2
+// structural panel, since the SC-62 fits nicely there.
+
+@PART[structuralPanel2] {
+	%node_stack_top_sw = -0.5, 0.0275, -0.5, 0, 1, 0, 0
+	%node_stack_top_se =  0.5, 0.0275, -0.5, 0, 1, 0, 0
+	%node_stack_top_nw = -0.5, 0.0275,  0.5, 0, 1, 0, 0
+	%node_stack_top_ne =  0.5, 0.0275,  0.5, 0, 1, 0, 0
+	%node_stack_bottom_sw = -0.5,-0.0275, -0.5, 0, -1, 0, 0
+	%node_stack_bottom_se =  0.5,-0.0275, -0.5, 0, -1, 0, 0
+	%node_stack_bottom_nw = -0.5,-0.0275,  0.5, 0, -1, 0, 0
+	%node_stack_bottom_ne =  0.5,-0.0275,  0.5, 0, -1, 0, 0
+}


### PR DESCRIPTION
The SC-62 fits nicely in the center of the stock 1x1 structural panel, and it can be handy to position it the same way on the four of them that make up the 2x2 panel.