### PR TITLE
Allow stock science container to be carried on a kerbal's back

### DIFF
--- a/Patches/MM-StockParts.cfg
+++ b/Patches/MM-StockParts.cfg
@@ -18,6 +18,25 @@
 	}
 }
 
+// Allow the Experiment Storage Unit to be carried on a kerbal's back (like the
+// SC-62 container).
+
+@PART[ScienceBox]
+{
+	MODULE
+	{
+		name = ModuleKISItemEvaTweaker
+		carriable = true
+		equipMode = part
+		equipSlot = jetpack
+		equipMeshName = jetpack_base01
+		equipBoneName = bn_jetpack01
+		equipPos = (0,0.21,-0.3)
+		equipDir = (10,0,0)
+		runSpeed = 0.8
+	}
+}
+
 // Add an attachment node in the center of each quadrant of the stock 2x2
 // structural panel, since the SC-62 fits nicely there.
 


### PR DESCRIPTION
The stock Experiment Storage Unit has similar size and mass to the SC-62 KIS container, and it makes sense to let it be carried on a kerbal's back in the same way as the SC-62.

![science-box-carry](https://cloud.githubusercontent.com/assets/23350503/24319028/fce93a7c-10e6-11e7-9dc4-d559fc06ed77.jpg)