### PR TITLE
Autorename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ TestResults
 *.sln.docstates
 
 # Build results
+build/
 [Dd]ebug/
 [Rr]elease/
 x64/

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ else
 	endif
 endif
 
-KISFILES := $(wildcard Plugins/Source/*.cs) \
-	$(wildcard Plugins/Source/Properties/*.cs) 
+KISFILES := $(wildcard Source/*.cs) \
+	$(wildcard Source/Properties/*.cs)
 
 RESGEN2 := resgen2
-GMCS := gmcs
+GMCS := mcs
 GIT := git
 TAR := tar
 ZIP := zip
@@ -55,11 +55,13 @@ info:
 	@echo "================================"
 
 build: build/KIS.dll
-	
+
 build/%.dll: ${KISFILES}
 	mkdir -p build
 	${GMCS} -t:library -lib:"${MANAGED}" \
-		-r:Assembly-CSharp,Assembly-CSharp-firstpass,UnityEngine \
+		-r:Assembly-CSharp,Assembly-CSharp-firstpass \
+		-r:UnityEngine,UnityEngine.UI \
+		-lib:Binaries -r:KSPDev_Utils.0.30 \
 		-out:$@ \
 		${KISFILES}
 

--- a/Source/KISAddonConfig.cs
+++ b/Source/KISAddonConfig.cs
@@ -56,6 +56,21 @@ sealed class KISAddonConfig : MonoBehaviour {
     int loadedPartCount;
     int loadedPartIndex;
 
+    bool HasPodInventories (Part part)
+    {
+      for (int i = part.Modules.Count; i-- > 0; ) {
+        var inv = part.Modules[i] as ModuleKISInventory;
+        if (inv == null) {
+          continue;
+        }
+        if (inv.invType == ModuleKISInventory.InventoryType.Pod) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+
     IEnumerator LoadInventories ()
     {
       // Kerbal parts.
@@ -69,6 +84,12 @@ sealed class KISAddonConfig : MonoBehaviour {
         if (!(avPart.name == MaleKerbalEva || avPart.name == FemaleKerbalEva
               || avPart.name == RdKerbalEva
               || !avPart.partPrefab || avPart.partPrefab.CrewCapacity < 1)) {
+          if (HasPodInventories (avPart.partPrefab)) {
+            // pod inventories have already been added to the part by another
+            // mod, so skip the part (probably a dynamic crew capacity)
+			  DebugEx.Info("Skipping " + avPart.partPrefab);
+            continue;
+          }
           DebugEx.Fine("Found part with CrewCapacity: {0}", avPart.name);
           AddPodInventories (avPart.partPrefab, avPart.partPrefab.CrewCapacity);
         }

--- a/Source/KISAddonConfig.cs
+++ b/Source/KISAddonConfig.cs
@@ -1,13 +1,14 @@
 ﻿using KSPDev.ConfigUtils;
 using KSPDev.LogUtils;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
 namespace KIS {
 
-[KSPAddon(KSPAddon.Startup.SpaceCentre, true)]
+[KSPAddon(KSPAddon.Startup.Instantly, false)]
 [PersistentFieldsDatabase("KIS/settings/KISConfig")]
 sealed class KISAddonConfig : MonoBehaviour {
   [PersistentField("StackableItemOverride/partName", isCollection = true)]
@@ -22,52 +23,133 @@ sealed class KISAddonConfig : MonoBehaviour {
   const string MaleKerbalEva = "kerbalEVA";
   const string FemaleKerbalEva = "kerbalEVAfemale";
   const string RdKerbalEva = "kerbalEVA_RD";
-  
-  public void Awake() {
-    ConfigAccessor.ReadFieldsInType(GetType(), this);
-    ConfigAccessor.ReadFieldsInType(typeof(ModuleKISInventory), instance: null);
 
-    // Set inventory module for every eva kerbal
-    DebugEx.Info("Set KIS config...");
-    ConfigNode nodeSettings = GameDatabase.Instance.GetConfigNode("KIS/settings/KISConfig");
-    if (nodeSettings == null) {
-      DebugEx.Error("KIS settings.cfg not found or invalid !");
-      return;
+  static ConfigNode nodeSettings;
+
+  class KISConfigLoader: LoadingSystem
+  {
+    public KISAddonConfig owner;
+
+    public override bool IsReady ()
+    {
+      return true;
     }
 
-    // Kerbal parts.
-    UpdateEvaPrefab(MaleKerbalEva, nodeSettings);
-    UpdateEvaPrefab(FemaleKerbalEva, nodeSettings);
+    public override void StartLoad ()
+    {
+      ConfigAccessor.ReadFieldsInType(owner.GetType(), owner);
+      ConfigAccessor.ReadFieldsInType(typeof(ModuleKISInventory), instance: null);
 
-    // Set inventory module for every pod with crew capacity.
-    DebugEx.Info("Loading pod inventories...");
-    foreach (AvailablePart avPart in PartLoader.LoadedPartsList) {
-      if (avPart.name == MaleKerbalEva || avPart.name == FemaleKerbalEva
-          || avPart.name == RdKerbalEva
-          || !avPart.partPrefab || avPart.partPrefab.CrewCapacity < 1) {
-        continue;
+      // Set inventory module for every eva kerbal
+      DebugEx.Info("Set KIS config...");
+      nodeSettings = GameDatabase.Instance.GetConfigNode("KIS/settings/KISConfig");
+      if (nodeSettings == null) {
+        DebugEx.Error("KIS settings.cfg not found or invalid !");
       }
+    }
+  }
 
-      DebugEx.Fine("Found part with CrewCapacity: {0}", avPart.name);
-      for (int i = 0; i < avPart.partPrefab.CrewCapacity; i++) {
-        try {
-          var moduleInventory =
-            avPart.partPrefab.AddModule(typeof(ModuleKISInventory).Name) as ModuleKISInventory;
-          KIS_Shared.AwakePartModule(moduleInventory);
-          var baseFields = new BaseFieldList(moduleInventory);
-          baseFields.Load(nodeSettings.GetNode("EvaInventory"));
-          moduleInventory.podSeat = i;
-          moduleInventory.invType = ModuleKISInventory.InventoryType.Pod;
-          DebugEx.Fine("Pod inventory module(s) for seat {0} loaded successfully", i);
-        } catch {
-          DebugEx.Error("Pod inventory module(s) for seat {0} can't be loaded!", i);
+  class KISPodInventoryLoader: LoadingSystem
+  {
+    public bool done;
+
+    int loadedPartCount;
+    int loadedPartIndex;
+
+    IEnumerator LoadInventories ()
+    {
+      // Kerbal parts.
+      UpdateEvaPrefab(MaleKerbalEva, nodeSettings);
+      UpdateEvaPrefab(FemaleKerbalEva, nodeSettings);
+
+      // Set inventory module for every pod with crew capacity.
+      DebugEx.Info("Loading pod inventories...");
+      for (loadedPartIndex = 0; loadedPartIndex < loadedPartCount; loadedPartIndex++) {
+        AvailablePart avPart = PartLoader.LoadedPartsList[loadedPartIndex];
+        if (!(avPart.name == MaleKerbalEva || avPart.name == FemaleKerbalEva
+              || avPart.name == RdKerbalEva
+              || !avPart.partPrefab || avPart.partPrefab.CrewCapacity < 1)) {
+          DebugEx.Fine("Found part with CrewCapacity: {0}", avPart.name);
+          AddPodInventories (avPart.partPrefab, avPart.partPrefab.CrewCapacity);
+        }
+        yield return null;
+      }
+      done = true;
+    }
+
+    public override bool IsReady ()
+    {
+      return done;
+    }
+
+    public override float ProgressFraction ()
+    {
+      return (float)loadedPartIndex / (float)loadedPartCount;
+    }
+
+    public override string ProgressTitle ()
+    {
+      return "Kerbal Inventory System";
+    }
+
+    public override void StartLoad ()
+    {
+      done = false;
+      loadedPartCount = PartLoader.LoadedPartsList.Count;
+      StartCoroutine (LoadInventories ());
+    }
+  }
+
+  public void Awake() {
+    List<LoadingSystem> list = LoadingScreen.Instance.loaders;
+    if (list != null) {
+      for (int i = 0; i < list.Count; i++) {
+        if (list[i] is KISConfigLoader) {
+          (list[i] as KISConfigLoader).owner = this;
+        }
+        if (list[i] is KISPodInventoryLoader) {
+          (list[i] as KISPodInventoryLoader).done = false;
+        }
+        if (list[i] is PartLoader) {
+          GameObject go = new GameObject();
+
+          var invLoader = go.AddComponent<KISPodInventoryLoader> ();
+          // Cause the pod inventory loader to run AFTER the part loader.
+          list.Insert (i + 1, invLoader);
+
+          var cfgLoader = go.AddComponent<KISConfigLoader> ();
+          cfgLoader.owner = this;
+          // Cause the config loader to run BEFORE the part loader this ensures
+          // that the KIS configs are loaded after Module Manager has run but
+          // before any parts are loaded so KIS aware part modules can add
+          // pod inventories as necessary.
+          list.Insert (i, cfgLoader);
+          break;
         }
       }
     }
   }
 
+  public static void AddPodInventories (Part part, int crewCapacity)
+  {
+    for (int i = 0; i < crewCapacity; i++) {
+      try {
+        var moduleInventory =
+          part.AddModule(typeof(ModuleKISInventory).Name) as ModuleKISInventory;
+        KIS_Shared.AwakePartModule(moduleInventory);
+        var baseFields = new BaseFieldList(moduleInventory);
+        baseFields.Load(nodeSettings.GetNode("EvaInventory"));
+        moduleInventory.podSeat = i;
+        moduleInventory.invType = ModuleKISInventory.InventoryType.Pod;
+        DebugEx.Fine("Pod inventory module(s) for seat {0} loaded successfully", i);
+      } catch {
+        DebugEx.Error("Pod inventory module(s) for seat {0} can't be loaded!", i);
+      }
+    }
+  }
+
   /// <summary>Load config of EVA modules for the requested part name.</summary>
-  void UpdateEvaPrefab(string partName, ConfigNode nodeSettings) {
+  static void UpdateEvaPrefab(string partName, ConfigNode nodeSettings) {
     var prefab = PartLoader.getPartInfoByName(partName).partPrefab;
     if (LoadModuleConfig(prefab, typeof(ModuleKISInventory),
                          nodeSettings.GetNode("EvaInventory"))) {
@@ -78,7 +160,7 @@ sealed class KISAddonConfig : MonoBehaviour {
 
   /// <summary>Loads config values for the part's module fro the provided config node.</summary>
   /// <returns><c>true</c> if loaded successfully.</returns>
-  bool LoadModuleConfig(Part p, Type moduleType, ConfigNode node) {
+  static bool LoadModuleConfig(Part p, Type moduleType, ConfigNode node) {
     var module = p.GetComponent(moduleType);
     if (module == null) {
       DebugEx.Warning(

--- a/Source/KISAddonPickup.cs
+++ b/Source/KISAddonPickup.cs
@@ -807,7 +807,6 @@ sealed class KISAddonPickup : MonoBehaviour {
       return;
     }
 
-    ModuleKISPartDrag pDrag = part.GetComponent<ModuleKISPartDrag>();
     ModuleKISItem item = part.GetComponent<ModuleKISItem>();
     ModuleKISPartMount parentMount = null;
     if (part.parent) {

--- a/Source/KIS_Shared.cs
+++ b/Source/KIS_Shared.cs
@@ -1364,7 +1364,7 @@ public static class KIS_Shared {
     newVessel.id = Guid.NewGuid();
     if (newVessel.Initialize(false)) {
       var item = newPart.FindModuleImplementing <ModuleKISItem> ();
-      if (item != null && !item.vesselAutoRename) {
+      if (item == null || !item.vesselAutoRename) {
         newVessel.vesselName = newPart.partInfo.title;
       } else {
         string baseName = fromPart.vessel.vesselName;

--- a/Source/KIS_Shared.cs
+++ b/Source/KIS_Shared.cs
@@ -840,7 +840,7 @@ public static class KIS_Shared {
     // HACK: Accessing Fields property of a non-awaken module triggers NRE. If it happens then do
     // explicit awakening of the *base* module class.
     try {
-      var unused = module.Fields.GetEnumerator();
+      module.Fields.GetEnumerator();
     } catch {
       DebugEx.Warning(
           "WORKAROUND. Module {0} on part prefab is not awaken. Call Awake on it", module);
@@ -1181,7 +1181,7 @@ public static class KIS_Shared {
     // Find out if coupling with a new parent is needed/allowed.
     var moduleItem = assemblyRoot.GetComponent<ModuleKISItem>();
     var useExternalPartAttach = moduleItem != null && moduleItem.useExternalPartAttach;
-    if (tgtPart == null || moduleItem != null && moduleItem.useExternalPartAttach) {
+    if (tgtPart == null || useExternalPartAttach) {
       // Skip coupling logic.
       SendKISMessage(assemblyRoot, MessageAction.AttachEnd, srcAttachNode, tgtPart, tgtAttachNode);
       yield break;

--- a/Source/KIS_Shared.cs
+++ b/Source/KIS_Shared.cs
@@ -329,7 +329,7 @@ public static class KIS_Shared {
                         createPhysicsless: createPhysicsless));
     } else {
       // Create new part as a separate vessel.
-      newPart.StartCoroutine(WaitAndMakeLonePart(newPart, onPartReady));
+      newPart.StartCoroutine(WaitAndMakeLonePart(newPart, fromPart, onPartReady));
     }
     return newPart;
   }
@@ -1354,7 +1354,7 @@ public static class KIS_Shared {
 
   /// <summary>Creates a new vessel from a single part.</summary>
   /// <remarks>Initially the part must belong to some vessel.</remarks>
-  static IEnumerator WaitAndMakeLonePart(Part newPart, OnPartReady onPartReady) {
+  static IEnumerator WaitAndMakeLonePart(Part newPart, Part fromPart, OnPartReady onPartReady) {
     DebugEx.Info("Create lone part vessel for {0}", newPart);
     newPart.physicalSignificance = Part.PhysicalSignificance.NONE;
     newPart.PromoteToPhysicalPart();
@@ -1363,7 +1363,13 @@ public static class KIS_Shared {
     Vessel newVessel = newPart.gameObject.AddComponent<Vessel>();
     newVessel.id = Guid.NewGuid();
     if (newVessel.Initialize(false)) {
-      newVessel.vesselName = newPart.partInfo.title;
+      var item = newPart.FindModuleImplementing <ModuleKISItem> ();
+      if (item != null && !item.vesselAutoRename) {
+        newVessel.vesselName = newPart.partInfo.title;
+      } else {
+        string baseName = fromPart.vessel.vesselName;
+        newVessel.vesselName = Vessel.AutoRename (newVessel, baseName);
+      }
       newVessel.IgnoreGForces(10);
       newVessel.currentStage = StageManager.RecalculateVesselStaging(newVessel);
       newPart.setParent(null);

--- a/Source/KIS_Shared.cs
+++ b/Source/KIS_Shared.cs
@@ -329,7 +329,7 @@ public static class KIS_Shared {
                         createPhysicsless: createPhysicsless));
     } else {
       // Create new part as a separate vessel.
-      newPart.StartCoroutine(WaitAndMakeLonePart(newPart, fromPart, onPartReady));
+      newPart.StartCoroutine(WaitAndMakeLonePart(newPart, onPartReady));
     }
     return newPart;
   }
@@ -1354,8 +1354,9 @@ public static class KIS_Shared {
 
   /// <summary>Creates a new vessel from a single part.</summary>
   /// <remarks>Initially the part must belong to some vessel.</remarks>
-  static IEnumerator WaitAndMakeLonePart(Part newPart, Part fromPart, OnPartReady onPartReady) {
+  static IEnumerator WaitAndMakeLonePart(Part newPart, OnPartReady onPartReady) {
     DebugEx.Info("Create lone part vessel for {0}", newPart);
+    string originatingVesselName = newPart.vessel.vesselName;
     newPart.physicalSignificance = Part.PhysicalSignificance.NONE;
     newPart.PromoteToPhysicalPart();
     newPart.Unpack();
@@ -1367,8 +1368,7 @@ public static class KIS_Shared {
       if (item == null || !item.vesselAutoRename) {
         newVessel.vesselName = newPart.partInfo.title;
       } else {
-        string baseName = fromPart.vessel.vesselName;
-        newVessel.vesselName = Vessel.AutoRename (newVessel, baseName);
+        newVessel.vesselName = Vessel.AutoRename (newVessel, originatingVesselName);
       }
       newVessel.IgnoreGForces(10);
       newVessel.currentStage = StageManager.RecalculateVesselStaging(newVessel);

--- a/Source/ModuleKISInventory.cs
+++ b/Source/ModuleKISInventory.cs
@@ -546,7 +546,7 @@ public class ModuleKISInventory : PartModule,
   public Rect guiMainWindowPos;
   Rect guiDebugWindowPos = new Rect(0, 50, 500, 300);
   KIS_IconViewer icon = null;
-  Rect defaultEditorPos = new Rect(Screen.width / 3, 40, 10, 10);
+  //Rect defaultEditorPos = new Rect(Screen.width / 3, 40, 10, 10);
   Rect defaultFlightPos = new Rect(0, 50, 10, 10);
   Vector2 scrollPositionDbg;
   int splitQty = 1;
@@ -559,7 +559,7 @@ public class ModuleKISInventory : PartModule,
   // Context menu
   private KIS_Item contextItem;
   private bool contextClick = false;
-  private int contextSlot;
+  //private int contextSlot;
   private Rect contextRect;
 
   // Animation (Not tested)
@@ -1905,7 +1905,7 @@ public class ModuleKISInventory : PartModule,
         contextClick = true;
         contextItem = items[slotIndex];
         contextRect = textureRect;
-        contextSlot = slotIndex;
+        //contextSlot = slotIndex;
       }
     }
 

--- a/Source/ModuleKISItem.cs
+++ b/Source/ModuleKISItem.cs
@@ -151,6 +151,8 @@ public class ModuleKISItem : PartModule,
   [KSPField]
   public bool usableFromEditor;
   [KSPField]
+  public bool vesselAutoRename;
+  [KSPField]
   public string useName = "use";
   [KSPField]
   public bool stackable;

--- a/Source/ModuleKISItemBook.cs
+++ b/Source/ModuleKISItemBook.cs
@@ -78,7 +78,7 @@ public sealed class ModuleKISItemBook: ModuleKISItem,
   bool showPage = false;
   Texture2D pageTexture;
   Rect guiWindowPos;
-  KIS_Item currentItem;
+  //KIS_Item currentItem;
   #endregion
 
   #region PartModule overrides
@@ -111,7 +111,7 @@ public sealed class ModuleKISItemBook: ModuleKISItem,
   public override void OnItemGUI(KIS_Item item) {
     if (showPage) {
       GUI.skin = HighLogic.Skin;
-      currentItem = item;
+      //currentItem = item;
       guiWindowPos = GUILayout.Window(GetInstanceID(), guiWindowPos, GuiReader, ReaderWindowTitle);
     }
   }


### PR DESCRIPTION
This allows KIS items to specify they want to use Vessel.AutoRename based on the originating vessel's name rather than the item part's title. The default is to use the item part's title, but setting vesselAutoRename to true in the MODULE block alters this. This is most useful for EL's survey stakes, but other mods may find it useful.