### PR TITLE
Autorename2

### DIFF
--- a/Source/KIS_Shared.cs
+++ b/Source/KIS_Shared.cs
@@ -1364,7 +1364,7 @@ public static class KIS_Shared {
     newVessel.id = Guid.NewGuid();
     if (newVessel.Initialize(false)) {
       var item = newPart.FindModuleImplementing <ModuleKISItem> ();
-      if (item != null && !item.vesselAutoRename) {
+      if (item == null || !item.vesselAutoRename) {
         newVessel.vesselName = newPart.partInfo.title;
       } else {
         string baseName = fromPart.vessel.vesselName;

--- a/Source/KIS_Shared.cs
+++ b/Source/KIS_Shared.cs
@@ -329,7 +329,7 @@ public static class KIS_Shared {
                         createPhysicsless: createPhysicsless));
     } else {
       // Create new part as a separate vessel.
-      newPart.StartCoroutine(WaitAndMakeLonePart(newPart, onPartReady));
+      newPart.StartCoroutine(WaitAndMakeLonePart(newPart, fromPart, onPartReady));
     }
     return newPart;
   }
@@ -1354,7 +1354,7 @@ public static class KIS_Shared {
 
   /// <summary>Creates a new vessel from a single part.</summary>
   /// <remarks>Initially the part must belong to some vessel.</remarks>
-  static IEnumerator WaitAndMakeLonePart(Part newPart, OnPartReady onPartReady) {
+  static IEnumerator WaitAndMakeLonePart(Part newPart, Part fromPart, OnPartReady onPartReady) {
     DebugEx.Info("Create lone part vessel for {0}", newPart);
     newPart.physicalSignificance = Part.PhysicalSignificance.NONE;
     newPart.PromoteToPhysicalPart();
@@ -1363,7 +1363,13 @@ public static class KIS_Shared {
     Vessel newVessel = newPart.gameObject.AddComponent<Vessel>();
     newVessel.id = Guid.NewGuid();
     if (newVessel.Initialize(false)) {
-      newVessel.vesselName = newPart.partInfo.title;
+      var item = newPart.FindModuleImplementing <ModuleKISItem> ();
+      if (item != null && !item.vesselAutoRename) {
+        newVessel.vesselName = newPart.partInfo.title;
+      } else {
+        string baseName = fromPart.vessel.vesselName;
+        newVessel.vesselName = Vessel.AutoRename (newVessel, baseName);
+      }
       newVessel.IgnoreGForces(10);
       newVessel.currentStage = StageManager.RecalculateVesselStaging(newVessel);
       newPart.setParent(null);

--- a/Source/KIS_Shared.cs
+++ b/Source/KIS_Shared.cs
@@ -329,7 +329,7 @@ public static class KIS_Shared {
                         createPhysicsless: createPhysicsless));
     } else {
       // Create new part as a separate vessel.
-      newPart.StartCoroutine(WaitAndMakeLonePart(newPart, fromPart, onPartReady));
+      newPart.StartCoroutine(WaitAndMakeLonePart(newPart, onPartReady));
     }
     return newPart;
   }
@@ -1354,8 +1354,9 @@ public static class KIS_Shared {
 
   /// <summary>Creates a new vessel from a single part.</summary>
   /// <remarks>Initially the part must belong to some vessel.</remarks>
-  static IEnumerator WaitAndMakeLonePart(Part newPart, Part fromPart, OnPartReady onPartReady) {
+  static IEnumerator WaitAndMakeLonePart(Part newPart, OnPartReady onPartReady) {
     DebugEx.Info("Create lone part vessel for {0}", newPart);
+    string originatingVesselName = newPart.vessel.vesselName;
     newPart.physicalSignificance = Part.PhysicalSignificance.NONE;
     newPart.PromoteToPhysicalPart();
     newPart.Unpack();
@@ -1367,8 +1368,7 @@ public static class KIS_Shared {
       if (item == null || !item.vesselAutoRename) {
         newVessel.vesselName = newPart.partInfo.title;
       } else {
-        string baseName = fromPart.vessel.vesselName;
-        newVessel.vesselName = Vessel.AutoRename (newVessel, baseName);
+        newVessel.vesselName = Vessel.AutoRename (newVessel, originatingVesselName);
       }
       newVessel.IgnoreGForces(10);
       newVessel.currentStage = StageManager.RecalculateVesselStaging(newVessel);

--- a/Source/ModuleKISItem.cs
+++ b/Source/ModuleKISItem.cs
@@ -151,6 +151,8 @@ public class ModuleKISItem : PartModule,
   [KSPField]
   public bool usableFromEditor;
   [KSPField]
+  public bool vesselAutoRename;
+  [KSPField]
   public string useName = "use";
   [KSPField]
   public bool stackable;


### PR DESCRIPTION
This allows KIS items to specify they want to use Vessel.AutoRename based on the originating vessel's name rather than the item part's title. The default is to use the item part's title, but setting vesselAutoRename to true in the MODULE block alters this. This is most useful for EL's survey stakes, but other mods may find it useful.