### PR TITLE
Podinventories

### DIFF
--- a/Source/KISAddonConfig.cs
+++ b/Source/KISAddonConfig.cs
@@ -56,6 +56,21 @@ sealed class KISAddonConfig : MonoBehaviour {
     int loadedPartCount;
     int loadedPartIndex;
 
+    bool HasPodInventories (Part part)
+    {
+      for (int i = part.Modules.Count; i-- > 0; ) {
+        var inv = part.Modules[i] as ModuleKISInventory;
+        if (inv == null) {
+          continue;
+        }
+        if (inv.invType == ModuleKISInventory.InventoryType.Pod) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+
     IEnumerator LoadInventories ()
     {
       // Kerbal parts.
@@ -69,6 +84,12 @@ sealed class KISAddonConfig : MonoBehaviour {
         if (!(avPart.name == MaleKerbalEva || avPart.name == FemaleKerbalEva
               || avPart.name == RdKerbalEva
               || !avPart.partPrefab || avPart.partPrefab.CrewCapacity < 1)) {
+          if (HasPodInventories (avPart.partPrefab)) {
+            // pod inventories have already been added to the part by another
+            // mod, so skip the part (probably a dynamic crew capacity)
+			  DebugEx.Info("Skipping " + avPart.partPrefab);
+            continue;
+          }
           DebugEx.Fine("Found part with CrewCapacity: {0}", avPart.name);
           AddPodInventories (avPart.partPrefab, avPart.partPrefab.CrewCapacity);
         }

--- a/Source/KISAddonConfig.cs
+++ b/Source/KISAddonConfig.cs
@@ -1,13 +1,14 @@
 ﻿using KSPDev.ConfigUtils;
 using KSPDev.LogUtils;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
 namespace KIS {
 
-[KSPAddon(KSPAddon.Startup.SpaceCentre, true)]
+[KSPAddon(KSPAddon.Startup.Instantly, false)]
 [PersistentFieldsDatabase("KIS/settings/KISConfig")]
 sealed class KISAddonConfig : MonoBehaviour {
   [PersistentField("StackableItemOverride/partName", isCollection = true)]
@@ -22,52 +23,133 @@ sealed class KISAddonConfig : MonoBehaviour {
   const string MaleKerbalEva = "kerbalEVA";
   const string FemaleKerbalEva = "kerbalEVAfemale";
   const string RdKerbalEva = "kerbalEVA_RD";
-  
-  public void Awake() {
-    ConfigAccessor.ReadFieldsInType(GetType(), this);
-    ConfigAccessor.ReadFieldsInType(typeof(ModuleKISInventory), instance: null);
 
-    // Set inventory module for every eva kerbal
-    DebugEx.Info("Set KIS config...");
-    ConfigNode nodeSettings = GameDatabase.Instance.GetConfigNode("KIS/settings/KISConfig");
-    if (nodeSettings == null) {
-      DebugEx.Error("KIS settings.cfg not found or invalid !");
-      return;
+  static ConfigNode nodeSettings;
+
+  class KISConfigLoader: LoadingSystem
+  {
+    public KISAddonConfig owner;
+
+    public override bool IsReady ()
+    {
+      return true;
     }
 
-    // Kerbal parts.
-    UpdateEvaPrefab(MaleKerbalEva, nodeSettings);
-    UpdateEvaPrefab(FemaleKerbalEva, nodeSettings);
+    public override void StartLoad ()
+    {
+      ConfigAccessor.ReadFieldsInType(owner.GetType(), owner);
+      ConfigAccessor.ReadFieldsInType(typeof(ModuleKISInventory), instance: null);
 
-    // Set inventory module for every pod with crew capacity.
-    DebugEx.Info("Loading pod inventories...");
-    foreach (AvailablePart avPart in PartLoader.LoadedPartsList) {
-      if (avPart.name == MaleKerbalEva || avPart.name == FemaleKerbalEva
-          || avPart.name == RdKerbalEva
-          || !avPart.partPrefab || avPart.partPrefab.CrewCapacity < 1) {
-        continue;
+      // Set inventory module for every eva kerbal
+      DebugEx.Info("Set KIS config...");
+      nodeSettings = GameDatabase.Instance.GetConfigNode("KIS/settings/KISConfig");
+      if (nodeSettings == null) {
+        DebugEx.Error("KIS settings.cfg not found or invalid !");
       }
+    }
+  }
 
-      DebugEx.Fine("Found part with CrewCapacity: {0}", avPart.name);
-      for (int i = 0; i < avPart.partPrefab.CrewCapacity; i++) {
-        try {
-          var moduleInventory =
-            avPart.partPrefab.AddModule(typeof(ModuleKISInventory).Name) as ModuleKISInventory;
-          KIS_Shared.AwakePartModule(moduleInventory);
-          var baseFields = new BaseFieldList(moduleInventory);
-          baseFields.Load(nodeSettings.GetNode("EvaInventory"));
-          moduleInventory.podSeat = i;
-          moduleInventory.invType = ModuleKISInventory.InventoryType.Pod;
-          DebugEx.Fine("Pod inventory module(s) for seat {0} loaded successfully", i);
-        } catch {
-          DebugEx.Error("Pod inventory module(s) for seat {0} can't be loaded!", i);
+  class KISPodInventoryLoader: LoadingSystem
+  {
+    public bool done;
+
+    int loadedPartCount;
+    int loadedPartIndex;
+
+    IEnumerator LoadInventories ()
+    {
+      // Kerbal parts.
+      UpdateEvaPrefab(MaleKerbalEva, nodeSettings);
+      UpdateEvaPrefab(FemaleKerbalEva, nodeSettings);
+
+      // Set inventory module for every pod with crew capacity.
+      DebugEx.Info("Loading pod inventories...");
+      for (loadedPartIndex = 0; loadedPartIndex < loadedPartCount; loadedPartIndex++) {
+        AvailablePart avPart = PartLoader.LoadedPartsList[loadedPartIndex];
+        if (!(avPart.name == MaleKerbalEva || avPart.name == FemaleKerbalEva
+              || avPart.name == RdKerbalEva
+              || !avPart.partPrefab || avPart.partPrefab.CrewCapacity < 1)) {
+          DebugEx.Fine("Found part with CrewCapacity: {0}", avPart.name);
+          AddPodInventories (avPart.partPrefab, avPart.partPrefab.CrewCapacity);
+        }
+        yield return null;
+      }
+      done = true;
+    }
+
+    public override bool IsReady ()
+    {
+      return done;
+    }
+
+    public override float ProgressFraction ()
+    {
+      return (float)loadedPartIndex / (float)loadedPartCount;
+    }
+
+    public override string ProgressTitle ()
+    {
+      return "Kerbal Inventory System";
+    }
+
+    public override void StartLoad ()
+    {
+      done = false;
+      loadedPartCount = PartLoader.LoadedPartsList.Count;
+      StartCoroutine (LoadInventories ());
+    }
+  }
+
+  public void Awake() {
+    List<LoadingSystem> list = LoadingScreen.Instance.loaders;
+    if (list != null) {
+      for (int i = 0; i < list.Count; i++) {
+        if (list[i] is KISConfigLoader) {
+          (list[i] as KISConfigLoader).owner = this;
+        }
+        if (list[i] is KISPodInventoryLoader) {
+          (list[i] as KISPodInventoryLoader).done = false;
+        }
+        if (list[i] is PartLoader) {
+          GameObject go = new GameObject();
+
+          var invLoader = go.AddComponent<KISPodInventoryLoader> ();
+          // Cause the pod inventory loader to run AFTER the part loader.
+          list.Insert (i + 1, invLoader);
+
+          var cfgLoader = go.AddComponent<KISConfigLoader> ();
+          cfgLoader.owner = this;
+          // Cause the config loader to run BEFORE the part loader this ensures
+          // that the KIS configs are loaded after Module Manager has run but
+          // before any parts are loaded so KIS aware part modules can add
+          // pod inventories as necessary.
+          list.Insert (i, cfgLoader);
+          break;
         }
       }
     }
   }
 
+  public static void AddPodInventories (Part part, int crewCapacity)
+  {
+    for (int i = 0; i < crewCapacity; i++) {
+      try {
+        var moduleInventory =
+          part.AddModule(typeof(ModuleKISInventory).Name) as ModuleKISInventory;
+        KIS_Shared.AwakePartModule(moduleInventory);
+        var baseFields = new BaseFieldList(moduleInventory);
+        baseFields.Load(nodeSettings.GetNode("EvaInventory"));
+        moduleInventory.podSeat = i;
+        moduleInventory.invType = ModuleKISInventory.InventoryType.Pod;
+        DebugEx.Fine("Pod inventory module(s) for seat {0} loaded successfully", i);
+      } catch {
+        DebugEx.Error("Pod inventory module(s) for seat {0} can't be loaded!", i);
+      }
+    }
+  }
+
   /// <summary>Load config of EVA modules for the requested part name.</summary>
-  void UpdateEvaPrefab(string partName, ConfigNode nodeSettings) {
+  static void UpdateEvaPrefab(string partName, ConfigNode nodeSettings) {
     var prefab = PartLoader.getPartInfoByName(partName).partPrefab;
     if (LoadModuleConfig(prefab, typeof(ModuleKISInventory),
                          nodeSettings.GetNode("EvaInventory"))) {
@@ -78,7 +160,7 @@ sealed class KISAddonConfig : MonoBehaviour {
 
   /// <summary>Loads config values for the part's module fro the provided config node.</summary>
   /// <returns><c>true</c> if loaded successfully.</returns>
-  bool LoadModuleConfig(Part p, Type moduleType, ConfigNode node) {
+  static bool LoadModuleConfig(Part p, Type moduleType, ConfigNode node) {
     var module = p.GetComponent(moduleType);
     if (module == null) {
       DebugEx.Warning(

--- a/Source/KISAddonConfig.cs
+++ b/Source/KISAddonConfig.cs
@@ -56,7 +56,7 @@ sealed class KISAddonConfig : MonoBehaviour {
     int loadedPartCount;
     int loadedPartIndex;
 
-    IEnumerator LoadInventories ()
+    void LoadInventories ()
     {
       // Kerbal parts.
       UpdateEvaPrefab(MaleKerbalEva, nodeSettings);
@@ -72,9 +72,7 @@ sealed class KISAddonConfig : MonoBehaviour {
           DebugEx.Fine("Found part with CrewCapacity: {0}", avPart.name);
           AddPodInventories (avPart.partPrefab, avPart.partPrefab.CrewCapacity);
         }
-        yield return null;
       }
-      done = true;
     }
 
     public override bool IsReady ()
@@ -94,9 +92,9 @@ sealed class KISAddonConfig : MonoBehaviour {
 
     public override void StartLoad ()
     {
-      done = false;
+      done = true;
       loadedPartCount = PartLoader.LoadedPartsList.Count;
-      StartCoroutine (LoadInventories ());
+      LoadInventories ();
     }
   }
 

--- a/Source/KISAddonConfig.cs
+++ b/Source/KISAddonConfig.cs
@@ -56,21 +56,6 @@ sealed class KISAddonConfig : MonoBehaviour {
     int loadedPartCount;
     int loadedPartIndex;
 
-    bool HasPodInventories (Part part)
-    {
-      for (int i = part.Modules.Count; i-- > 0; ) {
-        var inv = part.Modules[i] as ModuleKISInventory;
-        if (inv == null) {
-          continue;
-        }
-        if (inv.invType == ModuleKISInventory.InventoryType.Pod) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-
     IEnumerator LoadInventories ()
     {
       // Kerbal parts.
@@ -84,12 +69,6 @@ sealed class KISAddonConfig : MonoBehaviour {
         if (!(avPart.name == MaleKerbalEva || avPart.name == FemaleKerbalEva
               || avPart.name == RdKerbalEva
               || !avPart.partPrefab || avPart.partPrefab.CrewCapacity < 1)) {
-          if (HasPodInventories (avPart.partPrefab)) {
-            // pod inventories have already been added to the part by another
-            // mod, so skip the part (probably a dynamic crew capacity)
-			  DebugEx.Info("Skipping " + avPart.partPrefab);
-            continue;
-          }
           DebugEx.Fine("Found part with CrewCapacity: {0}", avPart.name);
           AddPodInventories (avPart.partPrefab, avPart.partPrefab.CrewCapacity);
         }


### PR DESCRIPTION
This moves the code that adds pod inventories into a standalone static function so KIS-aware mods can force-add pod inventories to parts that start with 0 crew capacity but can change in-flight (eg, inflatable habitats).

The dual-loader code is there to ensure KIS's configs are loaded before any parts are loaded and thus before any mod's part modules are loaded, and then KIS itself can run through the parts adding pod inventories as needed after the parts have been loaded. As it is now part of the loading process, this means pod inventories are added before the main menu screen comes up rather than after entering the space center scene.