### PR TITLE
Wrong key in default settings.cfg

### DIFF
--- a/settings.cfg
+++ b/settings.cfg
@@ -80,7 +80,7 @@ KISConfig
 		redockKey = y
 		allowPartAttach = false
 		allowStaticAttach = false
-		allowSnapAttach = false
+		allowPartStack = false
 		maxDistance = 3
 		grabMaxMass = 1
 		dropSndPath = KIS/Sounds/drop


### PR DESCRIPTION
The default settings.cfg has the wrong key for ModuleKISPickup.allowPartStack. 

The key allowSnapAttach doesn't seem to be used anywhere at all.