### PR TITLE
Fix version file for 1.22

### DIFF
--- a/KIS.version
+++ b/KIS.version
@@ -4,7 +4,7 @@
     "KSP_VERSION": {
         "MAJOR": 1, 
         "MINOR": 7, 
-        "PATCH": 0
+        "PATCH": 1
     }, 
     "KSP_VERSION_MAX": {
         "MAJOR": 1, 
@@ -14,7 +14,7 @@
     "KSP_VERSION_MIN": {
         "MAJOR": 1, 
         "MINOR": 7, 
-        "PATCH": 0
+        "PATCH": 1
     }, 
     "NAME": "Kerbal Inventory System", 
     "URL": "https://raw.githubusercontent.com/ihsoft/KIS/master/KIS.version", 


### PR DESCRIPTION
See https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1260-baikonur/&do=findComment&comment=3613088

According to that post, KIS 1.22 is compatible with KSP 1.7.1 but not 1.7.0. But its version file announces compatibility with KSP 1.7.0. This pull request fixes that.