### PR TITLE
Raycast attach node to check for colliders

### DIFF
--- a/Source/KISAddonPointer.cs
+++ b/Source/KISAddonPointer.cs
@@ -731,7 +731,7 @@ sealed class KISAddonPointer : MonoBehaviour {
     return a.distance.CompareTo(b.distance);
   }
 
-  static void CreateAutoOffsets(List<Collider> colliders) {
+  static void CreateAutoOffsets(Part part, List<Collider> colliders) {
     float distance = 1;
     int layerMask = (int)KspLayerMask.Part;
     int index = 0;
@@ -740,8 +740,10 @@ sealed class KISAddonPointer : MonoBehaviour {
     autoOffsets = new float[attachNodes.Count];
     foreach (var node in attachNodes) {
       autoOffsets[index] = 0;
+      Vector3 pos = part.transform.TransformPoint(node.position);
+      Vector3 dir = part.transform.TransformDirection(node.orientation);
 
-      var ray = new Ray(node.position + distance * node.orientation, -node.orientation);
+      var ray = new Ray(pos + distance * dir, -dir);
       var hits = Physics.RaycastAll(ray, distance, layerMask, triggers);
       Array.Sort(hits, CompareDistance);
       foreach (var hit in hits) {
@@ -785,7 +787,7 @@ sealed class KISAddonPointer : MonoBehaviour {
     pointer = new GameObject("KISPointer");
     var model = KISAPI.PartUtils.GetSceneAssemblyModel(rootPart, keepColliders: true);
     var colliders = model.GetComponentsInChildren<Collider>().ToList();
-    CreateAutoOffsets (colliders);
+    CreateAutoOffsets (rootPart, colliders);
     aboveAutoOffset = autoOffsets[attachNodeIndex];
     foreach (var collider in colliders) {
       UnityEngine.Object.DestroyImmediate (collider);

--- a/Source/KISAddonPointer.cs
+++ b/Source/KISAddonPointer.cs
@@ -733,7 +733,7 @@ sealed class KISAddonPointer : MonoBehaviour {
 
   static void CreateAutoOffsets(List<Collider> colliders) {
     float distance = 1;
-    int layerMask = 1 << 0;
+    int layerMask = (int)KspLayerMask.Part;
     int index = 0;
     var triggers = QueryTriggerInteraction.Ignore;
 
@@ -783,7 +783,7 @@ sealed class KISAddonPointer : MonoBehaviour {
 
     // Collect models from all the part in the assembly.
     pointer = new GameObject("KISPointer");
-    var model = KISAPI.PartUtils.GetSceneAssemblyModel(rootPart, true, true);
+    var model = KISAPI.PartUtils.GetSceneAssemblyModel(rootPart, keepColliders: true);
     var colliders = model.GetComponentsInChildren<Collider>().ToList();
     CreateAutoOffsets (colliders);
     aboveAutoOffset = autoOffsets[attachNodeIndex];

--- a/Source/KISAddonPointer.cs
+++ b/Source/KISAddonPointer.cs
@@ -179,8 +179,10 @@ sealed class KISAddonPointer : MonoBehaviour {
   static readonly List<Renderer> allModelRenderers = new List<Renderer>();
   static Vector3 customRot = new Vector3(0f, 0f, 0f);
   static float aboveDistance = 0;
+  static float aboveAutoOffset = 0;
   static Transform pointerNodeTransform;
   static List<AttachNode> attachNodes = new List<AttachNode>();
+  static float []autoOffsets;
 
   /// <summary>Index of the current node on the picked up part to attach with.</summary>
   /// <remarks>
@@ -199,6 +201,10 @@ sealed class KISAddonPointer : MonoBehaviour {
         _attachNodeIndex = value;
       }
       currentAttachNode = attachNodes[value];
+      aboveAutoOffset = 0;
+      if (autoOffsets != null) {
+        aboveAutoOffset = autoOffsets[value];
+      }
     }
   }
   static int _attachNodeIndex;
@@ -567,7 +573,7 @@ sealed class KISAddonPointer : MonoBehaviour {
           aboveDistance = 0;
         }
         pointer.transform.position =
-            pointer.transform.position + (hit.normal.normalized * aboveDistance);
+            pointer.transform.position + (hit.normal.normalized * (aboveDistance + aboveAutoOffset));
       }
     }
 
@@ -720,6 +726,34 @@ sealed class KISAddonPointer : MonoBehaviour {
     DebugEx.Fine("Pointer state set to: visibility={0}", isVisible);
   }
 
+  static int CompareDistance(RaycastHit a, RaycastHit b)
+  {
+    return a.distance.CompareTo(b.distance);
+  }
+
+  static void CreateAutoOffsets(List<Collider> colliders) {
+    float distance = 1;
+    int layerMask = 1 << 0;
+    int index = 0;
+    var triggers = QueryTriggerInteraction.Ignore;
+
+    autoOffsets = new float[attachNodes.Count];
+    foreach (var node in attachNodes) {
+      autoOffsets[index] = 0;
+
+      var ray = new Ray(node.position + distance * node.orientation, -node.orientation);
+      var hits = Physics.RaycastAll(ray, distance, layerMask, triggers);
+      Array.Sort(hits, CompareDistance);
+      foreach (var hit in hits) {
+        if (colliders.Contains (hit.collider)) {
+          autoOffsets[index] = distance - hit.distance;
+          break;
+        }
+      }
+      index++;
+    }
+  }
+
   /// <summary>Makes a game object to represent currently dragging assembly.</summary>
   /// <remarks>It's a very expensive operation.</remarks>
   static void MakePointer(Part rootPart) {
@@ -750,6 +784,12 @@ sealed class KISAddonPointer : MonoBehaviour {
     // Collect models from all the part in the assembly.
     pointer = new GameObject("KISPointer");
     var model = KISAPI.PartUtils.GetSceneAssemblyModel(rootPart);
+    var colliders = KISAPI.PartUtils.FindColliders (model);
+    CreateAutoOffsets (colliders);
+    aboveAutoOffset = autoOffsets[attachNodeIndex];
+    foreach (var collider in colliders) {
+      UnityEngine.Object.DestroyImmediate (collider);
+    }
     model.transform.parent = pointer.transform;
     model.transform.position = Vector3.zero;
     model.transform.rotation = Quaternion.identity;

--- a/Source/KISAddonPointer.cs
+++ b/Source/KISAddonPointer.cs
@@ -783,8 +783,8 @@ sealed class KISAddonPointer : MonoBehaviour {
 
     // Collect models from all the part in the assembly.
     pointer = new GameObject("KISPointer");
-    var model = KISAPI.PartUtils.GetSceneAssemblyModel(rootPart);
-    var colliders = KISAPI.PartUtils.FindColliders (model);
+    var model = KISAPI.PartUtils.GetSceneAssemblyModel(rootPart, true, true);
+    var colliders = model.GetComponentsInChildren<Collider>().ToList();
     CreateAutoOffsets (colliders);
     aboveAutoOffset = autoOffsets[attachNodeIndex];
     foreach (var collider in colliders) {

--- a/Source/api/Utils/PartUtilsImpl.cs
+++ b/Source/api/Utils/PartUtilsImpl.cs
@@ -109,6 +109,9 @@ public class PartUtilsImpl {
   /// <param name="goThruChildren">
   /// Tells if the parts down the hierarchy need to be captured too.
   /// </param>
+  /// <param name="keepColliders">
+  /// Keep the part colliders if true, otherwise they will be removed from the assembly.
+  /// </param>
   /// <returns>
   /// The root game object of the new hirerarchy. This object must be explicitly disposed when not
   /// needed anymore.

--- a/Source/api/Utils/PartUtilsImpl.cs
+++ b/Source/api/Utils/PartUtilsImpl.cs
@@ -113,7 +113,7 @@ public class PartUtilsImpl {
   /// The root game object of the new hirerarchy. This object must be explicitly disposed when not
   /// needed anymore.
   /// </returns>
-  public GameObject GetSceneAssemblyModel(Part rootPart, bool goThruChildren = true) {
+  public GameObject GetSceneAssemblyModel(Part rootPart, bool goThruChildren = true, bool keepColliders = false) {
     var modelObj = new GameObject("KisAssemblyRoot");
     modelObj.SetActive(true);
 
@@ -143,7 +143,7 @@ public class PartUtilsImpl {
         joints.Add(joint);
         continue;  // They must be handled before the connected RBs handled.
       }
-      if (!(component is Renderer || component is MeshFilter || component is Collider)) {
+      if (!(component is Renderer || component is MeshFilter || (keepColliders && component is Collider))) {
         UnityEngine.Object.DestroyImmediate(component);
       }
     }
@@ -167,18 +167,6 @@ public class PartUtilsImpl {
       }
     }
     return modelObj;
-  }
-
-  public List<Collider> FindColliders (GameObject modelObj)
-  {
-    var colliders = new List<Collider> ();
-
-    foreach (var component in modelObj.GetComponentsInChildren(typeof(Component))) {
-      if (component is Collider) {
-        colliders.Add (component as Collider);
-      }
-    }
-    return colliders;
   }
 
   /// <summary>Returns part's volume basing on its geometrics.</summary>

--- a/Source/api/Utils/PartUtilsImpl.cs
+++ b/Source/api/Utils/PartUtilsImpl.cs
@@ -143,7 +143,7 @@ public class PartUtilsImpl {
         joints.Add(joint);
         continue;  // They must be handled before the connected RBs handled.
       }
-      if (!(component is Renderer || component is MeshFilter)) {
+      if (!(component is Renderer || component is MeshFilter || component is Collider)) {
         UnityEngine.Object.DestroyImmediate(component);
       }
     }
@@ -167,6 +167,18 @@ public class PartUtilsImpl {
       }
     }
     return modelObj;
+  }
+
+  public List<Collider> FindColliders (GameObject modelObj)
+  {
+    var colliders = new List<Collider> ();
+
+    foreach (var component in modelObj.GetComponentsInChildren(typeof(Component))) {
+      if (component is Collider) {
+        colliders.Add (component as Collider);
+      }
+    }
+    return colliders;
   }
 
   /// <summary>Returns part's volume basing on its geometrics.</summary>


### PR DESCRIPTION
The ray cast is used to check whether then attach node is inside a
collider on the part to be dropped, and if so find the offset needed to
avoid dropping the part with the collider inside another collider, thus
preventing the part from flying off in low gravity. Of course, the
offset will not be sufficient of the collider surface is not
perpendicular to the attach node, or if the overall part collider setup
is concave around the attach node.

The computed offset works as a default value for the user-adjustable
offset.