### PR TITLE
Revert version file's VERSION.BUILD to match current release

### DIFF
--- a/KIS.version
+++ b/KIS.version
@@ -19,7 +19,7 @@
     "NAME": "Kerbal Inventory System", 
     "URL": "https://raw.githubusercontent.com/ihsoft/KIS/master/KIS.version", 
     "VERSION": {
-        "BUILD": 41065, 
+        "BUILD": 40880, 
         "MAJOR": 1, 
         "MINOR": 28, 
         "PATCH": 7685


### PR DESCRIPTION
4773123873b44d21ae1fa62aa3530c3453d3c6be changed VERSION.BUILD in the remote version file, which tells KSP-AVC and CKAN that it is for a different version than the download, which prevents the other changes in that commit from applying and keeps KIS 1.28 stuck as compatible with KSP 1.8.

Recommend changing the BUILD property back so it matches and the intended compatibility can be applied. If you have some kind of automated build script populating this, probably a good idea to remove that as well.

Tagging @ihsoft to ensure GitHub sends a notification.