### PR TITLE
ModuleManager patch ordering for compatibility with ReStock 1.5.0

### DIFF
--- a/Patches/MM-DLC-Breaking-Grounds.cfg
+++ b/Patches/MM-DLC-Breaking-Grounds.cfg
@@ -1,4 +1,4 @@
-@PART[smallCargoContainer] {
+@PART[smallCargoContainer]:FOR[KIS] {
 	MODULE
 	{
 		name = ModuleKISItem
@@ -11,7 +11,7 @@
 	}
 }
 
-+PART[smallCargoContainer]
++PART[smallCargoContainer]:FOR[KIS]
 {
 	@name = mediumCargoContainer
 	@rescaleFactor = 1.33


### PR DESCRIPTION
ReStock 1.5.0 blacklists the stock cargo container assets, causing mediumCargoContainer (a ModuleManager copy of smallCargoContainer) to be invalid. Marking these patches as :FOR[KIS] ensures they are run by ModuleManager after ReStock has done its thing.