### PR TITLE
Remove lag-causing function call

### DIFF
--- a/Source/KISAddonPointer.cs
+++ b/Source/KISAddonPointer.cs
@@ -883,7 +883,6 @@ sealed class KISAddonPointer : MonoBehaviour {
     allModelRenderers.Clear();
 
     // On large assemblies memory consumption can be significant. Reclaim it.
-    Resources.UnloadUnusedAssets();
     DebugEx.Fine("Pointer destroyed");
   }
 }


### PR DESCRIPTION
In highly modded installs this one call causes more than a second of lag upon placing a grabbed part.